### PR TITLE
Fix error on 3D CT experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ skimage: 0.17.2
 yaml: 0.1.7
 opencv: 3.4.2
 odl: 1.0.0.dev0
+astra-toolbox
 ```
 
 

--- a/ct_geometry_projector.py
+++ b/ct_geometry_projector.py
@@ -64,7 +64,7 @@ def build_conebeam_gemotry(param):
                                           det_radius=param.param['dde'], # radius of the detector circle 
                                           axis=[0, 0, 1]) # rotation axis is z-axis: (0, 0, 1)
     
-    ray_trafo = odl.tomo.RayTransform(domain=reco_space, # domain of forward projector
+    ray_trafo = odl.tomo.RayTransform(vol_space=reco_space, # domain of forward projector
                                      geometry=geometry, # geometry of the transform
                                      impl='astra_cuda') # implementation back-end for the transform: ASTRA toolbox, using CUDA, 2D or 3D
     


### PR DESCRIPTION
As described in Issue #3, an error arose when running the 3D CT experiment [train_ct_recon_3d.py](https://github.com/liyues/NeRP/blob/72ecb6f1c0adbe4a3b2748a50a270507232ce545/train_ct_recon_3d.py). The reason is the mismatched argument name of odl function `odl.tomo.RayTransform()` in [ct_geometry_projector.py](https://github.com/liyues/NeRP/blob/72ecb6f1c0adbe4a3b2748a50a270507232ce545/ct_geometry_projector.py), the argument name is changed from 'domain' to 'vol_space' as described in [ODL documentation](https://odlgroup.github.io/odl/generated/odl.tomo.operators.ray_trafo.RayTransform.html#odl.tomo.operators.ray_trafo.RayTransform) for `odl.tomo.RayTransform()`.

Besides, the original code used 'astra_cuda' as the backend for function `odl.tomo.RayTransform()` without specifying `astra-toolbox` as a dependency. As described in [Issue](https://github.com/jleuschn/learned_ct_reco_comparison_paper/issues/2#issuecomment-877784896), ODL requires astra-toolbox installed to be able to use `odl.tomo.RayTransform()` with 'astra_cuda' specified for 'impl'. I added `astra-toolbox` into the dependencies on README.md.